### PR TITLE
pypi-google-cloud-35 Fix TypeError: 'NoneType' object has no attribut…

### DIFF
--- a/install/pypi-template.py
+++ b/install/pypi-template.py
@@ -5,6 +5,9 @@ def generate_config(context):
         {
             'name': 'pypi-run',
             'type': 'run-template.py',
+            'properties': {
+                'region': context.properties['region'],
+            },
         },
         {
             'name': 'pypi-secret',


### PR DESCRIPTION
…e '__getitem__'  Resource: run-template.py Resource: config